### PR TITLE
Memory route and constraints, MemoryBar and PIL

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,7 +125,7 @@ def update_design_title():
 @jwt_required()
 def update_design_image():
     handler = Design(email=get_jwt_identity())
-    return handler.update_design_image(design_id=request.form.get('design_id'), image=request.files.get('image'))
+    return handler.update_design_image(design_id=request.form.get('design_id'), files=request.files)
 
 
 @app.route("/design/<int>:design_id/approval", methods=['PUT'])
@@ -141,6 +141,14 @@ def update_design_approval():
 def update_design_status():
     handler = Design(email=get_jwt_identity())
     return handler.update_design_status(design_id=request.form.get('design_id'), status=request.form.get('status'))
+
+
+# Memory-----------------------------------------------------------------------------------------------------------
+@app.route("/memory", methods=['GET'])
+@jwt_required()
+def get_user_memory():
+    handler = Design(email=get_jwt_identity())
+    return handler.get_user_bytes()
 
 
 # AdminAction-----------------------------------------------------------------------------------------------------------

--- a/controller/design.py
+++ b/controller/design.py
@@ -161,12 +161,12 @@ class Design:
             if user_bytes is None:
                 return jsonify(error="Couldn't get user memory"), 500
 
-            im, im_bytes = transform_image(image_file)
+            im, n_bytes = transform_image(image_file)
 
             if im is None:
                 return jsonify(error="Couldn't transform image"), 500
 
-            if self.get_num_bytes() + im_bytes > MAX_USER_CAPACITY_BYTES:
+            if self.get_num_bytes() + n_bytes > MAX_USER_CAPACITY_BYTES:
                 return jsonify(error="User exceeds the storage limit"), 400
 
             response = design_dao.update_design_image(design_id, im)

--- a/model/design.py
+++ b/model/design.py
@@ -59,7 +59,7 @@ class DesignDAO:
     def update_design_title(self, design_id: int, title: str):
         status = 1
         cursor = self.conn.cursor()
-        query = "UPDATE design SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?"
+        query = "UPDATE design SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?;"
 
         try:
             cursor.execute(query, (title, design_id))
@@ -74,7 +74,7 @@ class DesignDAO:
     def update_design_image(self, design_id: int, image):
         status = 1
         cursor = self.conn.cursor()
-        query = "UPDATE design SET image = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?"
+        query = "UPDATE design SET image = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?;"
 
         try:
             cursor.execute(query, (image, design_id))
@@ -89,7 +89,7 @@ class DesignDAO:
     def update_design_approval(self, design_id: int, is_approved: int):
         status = 1
         cursor = self.conn.cursor()
-        query = "UPDATE design SET is_approved = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?"
+        query = "UPDATE design SET is_approved = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?;"
 
         try:
             cursor.execute(query, (is_approved, design_id))
@@ -104,7 +104,7 @@ class DesignDAO:
     def update_design_status(self, design_id: int, design_status: int):
         status = 1
         cursor = self.conn.cursor()
-        query = "UPDATE design SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?"
+        query = "UPDATE design SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE design_id = ?;"
 
         try:
             cursor.execute(query, (design_status, design_id))
@@ -119,7 +119,7 @@ class DesignDAO:
     def delete_design(self, design_id):
         status = 1
         cursor = self.conn.cursor()
-        query = "DELETE FROM design WHERE design_id = ?"
+        query = "DELETE FROM design WHERE design_id = ?;"
 
         try:
             cursor.execute(query, (design_id,))
@@ -131,3 +131,17 @@ class DesignDAO:
         finally:
             cursor.close()
             return status
+
+    def get_user_bytes(self, user_id: int):
+        cursor = self.conn.cursor()
+        query = "SELECT SUM(LENGTH(image)) AS total_bytes FROM design WHERE user_id = ?;"
+
+        try:
+            cursor.execute(query, (user_id,))
+            result = cursor.fetchone()
+            return result[0] if result[0] is not None else 0
+
+        except sqlite3.Error:
+            return None
+        finally:
+            cursor.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ protobuf~=6.30.2
 google-auth==2.28.1
 google-api-python-client~=2.166.0
 google-auth-oauthlib~=1.2.1
+pillow~=11.1.0

--- a/utilities/create.py
+++ b/utilities/create.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-con = sqlite3.connect('data.db')
+con = sqlite3.connect('../data.db')
 cur = con.cursor()
 
 cur.execute("""

--- a/view/src/components/MemoryBar.jsx
+++ b/view/src/components/MemoryBar.jsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import axios from '../api/axios';
+
+export default function MemoryUsage() {
+    const [usedBytes, setUsedBytes] = useState(null);
+    const [maxMB, setMaxMB] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchUsage = async () => {
+            try {
+                const res = await axios.get('/memory');
+                setUsedBytes(res.data.bytes);
+                setMaxMB(res.data.max);
+            } catch (err) {
+                setError(error.response?.data?.error || 'Failed to get used memory.');
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchUsage();
+    }, []);
+
+    const formatMB = (bytes) => (bytes / (1024 * 1024)).toFixed(2);
+    const percent = usedBytes && maxMB
+        ? Math.min((usedBytes / (maxMB * 1024 * 1024)) * 100, 100).toFixed(1)
+        : 0;
+
+    return (
+        <div
+            className="max-w-md mx-auto mt-10 p-6 bg-white rounded-2xl shadow-md space-y-4"
+            style={{ fontFamily: '"Pixelify Sans", sans-serif' }}
+        >
+            <h2 className="text-2xl font-bold text-center text-gray-800">Storage Usage</h2>
+
+            {loading ? (
+                <p className="text-center text-gray-500">Loading...</p>
+            ) : error ? (
+                <div className="text-center p-2 rounded bg-red-100 text-red-700">{error}</div>
+            ) : (
+                <>
+                    <div className="w-full bg-gray-200 h-4 rounded-full overflow-hidden">
+                        <div
+                            className={`h-full transition-all duration-300 ease-out ${
+                                percent > 90 ? 'bg-red-500' : 'bg-blue-500'
+                            }`}
+                            style={{ width: `${percent}%` }}
+                        ></div>
+                    </div>
+
+                    <p className="text-center text-sm text-gray-700">
+                        {formatMB(usedBytes)} MB used of {maxMB} MB ({percent}%)
+                    </p>
+                </>
+            )}
+        </div>
+    );
+}

--- a/view/src/pages/UploadPage.jsx
+++ b/view/src/pages/UploadPage.jsx
@@ -2,6 +2,7 @@ import "../components/styles/Menu.css";
 import "../components/styles/Upload.css";
 import { useAuth } from '../auth/authContext'
 import {useState, useRef, useEffect} from "react";
+import MemoryBar from "../components/MemoryBar.jsx";
 
 function UploadPage() {
     const fileInputRef = useRef(null);
@@ -124,8 +125,10 @@ function UploadPage() {
                                           <button type="button" className="upload-button queue-button"
                                                   onClick={handleAddToQueue}>Add to Queue
                                           </button>
+
                                       </div>
                                   )}
+                                  <MemoryBar/>
                               </div>
                           </div>
                       </form>


### PR DESCRIPTION
### Feature Description
Adds the `MemoryBar` component to the project that gets the user's memory used against the total allowed memory. Adds the necessary endpoint for getting this data, and prevents users from uploading/editing images once they have exceeded the set memory limit.
### Solution Description

- Adds the `/memory` endpoint with JWT required which will return the number of bytes a user has in use and the number of maximum bytes set in the system for a user.
- When uploading or updating images, a memory check is performed to see if the new images would exceed the set limit.
- Adds the **Python Imaging Library** to transform the uploaded images to the desired constraints and turn them into bytes objects. See: https://pillow.readthedocs.io/en/stable/_modules/PIL/Image.html#Image.tobytes

### Preview
![image](https://github.com/user-attachments/assets/8a3ba52d-3f37-4247-8b42-3212e1dd63e3)
